### PR TITLE
Validate that inline snapshot source is within source directory.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,8 +107,9 @@ lazy val core = (projectMatrix in file("modules/core"))
   .jvmPlatform(
     scalaVersions = scalaVersions,
     libraryDependencies += "com.lihaoyi" %% "os-lib" % Versions.oslib
+  ).jsPlatform(scalaVersions = scalaVersions,
+    Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
   )
-  .jsPlatform(scalaVersions = scalaVersions)
 
 lazy val munit = (projectMatrix in file("modules/munit"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,7 @@ lazy val core = (projectMatrix in file("modules/core"))
     scalaVersions = scalaVersions,
     libraryDependencies += "com.lihaoyi" %% "os-lib" % Versions.oslib
   ).jsPlatform(scalaVersions = scalaVersions,
+    // module support is required to run tests
     Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
   )
 

--- a/modules/core/src/main/scala/com/siriusxm/snapshot4s/InlineSnapshot.scala
+++ b/modules/core/src/main/scala/com/siriusxm/snapshot4s/InlineSnapshot.scala
@@ -84,13 +84,15 @@ object InlineSnapshot {
     changeFile.write(actualStr)
   }
 
-  private def relativeSourceFilePath(
+  private[snapshot4s] def relativeSourceFilePath(
       sourceFile: String,
       config: SnapshotConfig
   ): RelPath = {
     val baseDirectory  = config.sourceDirectory
     val sourceFilePath = Path(sourceFile)
-    sourceFilePath.relativeTo(baseDirectory)
+    sourceFilePath.relativeTo(baseDirectory).getOrElse {
+      throw new SnapshotConfigUnsupportedError(config)
+    }
   }
 
   // See the Scala 2.13 compiler for the source of the warning we're ignoring:

--- a/modules/core/src/main/scala/com/siriusxm/snapshot4s/SnapshotConfigError.scala
+++ b/modules/core/src/main/scala/com/siriusxm/snapshot4s/SnapshotConfigError.scala
@@ -16,7 +16,7 @@
 
 package snapshot4s
 
-private final class SnapshotConfigUnsupportedError(config: SnapshotConfig) extends Throwable({
+private final class SnapshotConfigUnsupportedError(config: SnapshotConfig) extends Excepiton({
       s"""Your project setup is not supported by snapshot4s. We encourage you to raise an issue at https://github.com/siriusxm/snapshot4s.
 
 We have detected the following configuration:

--- a/modules/core/src/main/scala/com/siriusxm/snapshot4s/SnapshotConfigError.scala
+++ b/modules/core/src/main/scala/com/siriusxm/snapshot4s/SnapshotConfigError.scala
@@ -16,26 +16,12 @@
 
 package snapshot4s
 
-private[snapshot4s] trait PathApi {
+private final class SnapshotConfigUnsupportedError(config: SnapshotConfig) extends Throwable({
+      s"""Your project setup is not supported by snapshot4s. We encourage you to raise an issue at https://github.com/siriusxm/snapshot4s.
 
-  private[snapshot4s] def read(): String
-  private[snapshot4s] def write(contents: String): Unit
-  private[snapshot4s] def relativeTo(baseDirectory: Path): Option[RelPath]
-  private[snapshot4s] def /(path: RelPath): Path
-
-  private[snapshot4s] def exists(): Boolean
-
-  private[snapshot4s] def value: String
-}
-
-trait PathCompanionApi {
-  def apply(path: String): Path
-}
-
-private[snapshot4s] trait RelPathApi {
-  private[snapshot4s] def value: String
-}
-
-private[snapshot4s] trait RelPathCompanionApi {
-  def apply(path: String): RelPath
-}
+We have detected the following configuration:
+  - sourceDirectory: ${config.sourceDirectory.value}
+  - resourceDirectory: ${config.resourceDirectory.value}
+  - outputDirectory: ${config.outputDirectory.value}
+"""
+    })

--- a/modules/core/src/main/scala/com/siriusxm/snapshot4s/SnapshotConfigError.scala
+++ b/modules/core/src/main/scala/com/siriusxm/snapshot4s/SnapshotConfigError.scala
@@ -16,7 +16,7 @@
 
 package snapshot4s
 
-private final class SnapshotConfigUnsupportedError(config: SnapshotConfig) extends Excepiton({
+private final class SnapshotConfigUnsupportedError(config: SnapshotConfig) extends Exception({
       s"""Your project setup is not supported by snapshot4s. We encourage you to raise an issue at https://github.com/siriusxm/snapshot4s.
 
 We have detected the following configuration:

--- a/modules/core/src/main/scalajs/com/siriusxm/snapshot4s/Path.scala
+++ b/modules/core/src/main/scalajs/com/siriusxm/snapshot4s/Path.scala
@@ -44,7 +44,8 @@ final class Path private (override val toString: String) extends PathApi {
 
   private[snapshot4s] def relativeTo(baseDirectory: Path): Option[RelPath] = {
     val text = facade.relative(baseDirectory.toString, toString)
-    if (text.startsWith("..")) {
+    // Check that this path is in a subdirectory of the base directory.
+    if (text.startsWith("../")) {
       None
     } else {
       Some(RelPath(text))

--- a/modules/core/src/main/scalajs/com/siriusxm/snapshot4s/Path.scala
+++ b/modules/core/src/main/scalajs/com/siriusxm/snapshot4s/Path.scala
@@ -42,14 +42,22 @@ final class Path private (override val toString: String) extends PathApi {
     )
   }
 
-  private[snapshot4s] def relativeTo(baseDirectory: Path): RelPath =
-    RelPath(facade.relative(baseDirectory.toString, toString))
+  private[snapshot4s] def relativeTo(baseDirectory: Path): Option[RelPath] = {
+    val text = facade.relative(baseDirectory.toString, toString)
+    if (text.startsWith("..")) {
+      None
+    } else {
+      Some(RelPath(text))
+    }
+  }
 
   private[snapshot4s] def /(path: RelPath): Path =
     Path(facade.join(toString, path.toString))
 
   private[snapshot4s] def exists(): Boolean =
     facade.exists(toString)
+
+  private[snapshot4s] def value: String = toString
 }
 
 object Path extends PathCompanionApi {

--- a/modules/core/src/main/scalajs/com/siriusxm/snapshot4s/RelPath.scala
+++ b/modules/core/src/main/scalajs/com/siriusxm/snapshot4s/RelPath.scala
@@ -16,7 +16,9 @@
 
 package snapshot4s
 
-private[snapshot4s] final class RelPath private (override val toString: String)
+private[snapshot4s] final class RelPath private (override val toString: String) extends RelPathApi {
+  private[snapshot4s] def value: String = toString
+}
 
 private[snapshot4s] object RelPath extends RelPathCompanionApi {
   def apply(path: String): RelPath = new RelPath(path)

--- a/modules/core/src/main/scalajvm/com/siriusxm/snapshot4s/Path.scala
+++ b/modules/core/src/main/scalajvm/com/siriusxm/snapshot4s/Path.scala
@@ -23,13 +23,17 @@ final class Path private[snapshot4s] (val osPath: os.Path) extends PathApi {
   private[snapshot4s] def write(contents: String): Unit =
     os.write.over(osPath, contents, createFolders = true)
 
-  private[snapshot4s] def relativeTo(baseDirectory: Path): RelPath =
-    new RelPath(osPath.relativeTo(baseDirectory.osPath))
+  private[snapshot4s] def relativeTo(baseDirectory: Path): Option[RelPath] =
+    if (osPath.startsWith(baseDirectory.osPath))
+      Some(new RelPath(osPath.relativeTo(baseDirectory.osPath)))
+    else None
 
   private[snapshot4s] def /(path: RelPath): Path =
     new Path(osPath / path.osPath)
 
   def exists(): Boolean = os.exists(osPath)
+
+  private[snapshot4s] def value: String = osPath.toString
 }
 
 object Path extends PathCompanionApi {

--- a/modules/core/src/main/scalajvm/com/siriusxm/snapshot4s/RelPath.scala
+++ b/modules/core/src/main/scalajvm/com/siriusxm/snapshot4s/RelPath.scala
@@ -16,7 +16,9 @@
 
 package snapshot4s
 
-private[snapshot4s] final class RelPath(val osPath: os.PathChunk)
+private[snapshot4s] final class RelPath(val osPath: os.PathChunk) extends RelPathApi {
+  private[snapshot4s] def value: String = osPath.toString
+}
 
 object RelPath extends RelPathCompanionApi {
   def apply(path: String): RelPath =

--- a/modules/core/src/test/scala/com/siriusxm/snapshot4s/InlineSnapshotSpec.scala
+++ b/modules/core/src/test/scala/com/siriusxm/snapshot4s/InlineSnapshotSpec.scala
@@ -1,0 +1,42 @@
+package snapshot4s
+
+import cats.effect.IO
+import weaver.*
+
+object InlineSnapshotSpec extends SimpleIOSuite {
+
+  pureTest("calculates relative paths correctly") {
+    val config = new SnapshotConfig(
+      resourceDirectory = Path("/path/to/resources"),
+      outputDirectory = Path("/path/to/output"),
+      sourceDirectory = Path("/path/to/sources")
+    )
+    val relativePath =
+      InlineSnapshot.relativeSourceFilePath("/path/to/sources/TestFile.scala", config)
+    expect.eql(relativePath.value, "TestFile.scala")
+  }
+
+  test("raises errors if the source directory is calculated incorrectly") {
+    val config = new SnapshotConfig(
+      resourceDirectory = Path("/path/to/resources"),
+      outputDirectory = Path("/path/to/output"),
+      sourceDirectory = Path("/wrong/path/to/sources")
+    )
+    val result =
+      IO(InlineSnapshot.relativeSourceFilePath("/path/to/sources/TestFile.scala", config))
+    val message =
+      """Your project setup is not supported by snapshot4s. We encourage you to raise an issue at https://github.com/siriusxm/snapshot4s.
+
+We have detected the following configuration:
+  - sourceDirectory: /wrong/path/to/sources
+  - resourceDirectory: /path/to/resources
+  - outputDirectory: /path/to/output
+"""
+    result.attempt.map { result =>
+      matches(result) { case Left(err) =>
+        expect.eql(err.getMessage, message)
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
The `SnapshotConfig.sourceDirectory` is determined based on SBT settings.

That calculation is incorrect for cross projects, and may be wrong in many other cases.

This PR adds validation on the relative path calculation. `assertInlineSnapshot` raises an error if the source file is not within the determined source directory.