### PR TITLE
Remove core dependency.

### DIFF
--- a/modules/plugin/src/main/scala/com/siriusxm/snapshot/Snapshot4sPlugin.scala
+++ b/modules/plugin/src/main/scala/com/siriusxm/snapshot/Snapshot4sPlugin.scala
@@ -73,10 +73,7 @@ object generated {
         snapshot4sDirectory.value / "inline-patch",
         (Test / sourceDirectory).value
       )
-    },
-    libraryDependencies ++= Seq(
-      "com.siriusxm" %% "snapshot4s-core" % BuildInfo.snapshot4sVersion % Test
-    )
+    }
   )
 
   private def applyResourcePatches(log: Logger)(resourcePatchDir: File, resourceDir: File) = {


### PR DESCRIPTION
The `Snapshot4sPlugin` adds a `snapshot4s-core` module to `libraryDependencies`.

Users will always include `snapshot4s-munit` or `snapshot4s-weaver`. These pull in `snapshot4s-core` transitively, so the explicit addition is not needed.