### PR TITLE
Support `sbt-typelevel` and `sbt-crossproject`

### DIFF
--- a/docs/markdown/limitations.md
+++ b/docs/markdown/limitations.md
@@ -10,14 +10,6 @@ This page is a shortlist of the known limitations of snapshot4s. If you encounte
 
 `snapshot4s` doesn't yet support Scala Native.
 
-## `sbt-crossproject` is not supported
-
-`snapshot4s` doesn't yet support the `CrossType.Pure` project layout of `sbt-crossproject`. This means that projects using `sbt-typelevel` are also not supported.
-
-It should support all other project layouts, such as `sbt-projectmatrix`.
-
-Support for `sbt-crossproject` is [on our roadmap](https://github.com/siriusxm/snapshot4s/issues/28).
-
 ## Promoted code may fail to compile with `not found` errors
 
 `snapshot4s` uses `pprint` to efficiently generate the source code corresponding to an expected value.  This doesn’t add import statements for `enum` and classes within objects. You may need to add an import statement corresponding to the `enum` or object in question.

--- a/docs/markdown/sbt-setup.md
+++ b/docs/markdown/sbt-setup.md
@@ -9,8 +9,7 @@ You can enable `snapshot4s` for a variety of SBT project layouts.
  - For single project SBT builds follow [these instructions](#single-project-builds).
  - For multi-project SBT builds follow [these instructions](#multi-project-builds)
  - For `sbt-projectmatrix` follow [these instructions](#sbt-projectmatrix).
-
-snapshot4s does not yet support `sbt-crossproject` or `sbt-typelevel`. These are [on our roadmap](https://github.com/siriusxm/snapshot4s/issues/28).
+ - For `sbt-crossproject` and `sbt-typelevel` follow [these instructions](#sbt-crossproject-and-sbt-typelevel).
 
 ## Single project builds
 
@@ -52,6 +51,41 @@ Enable it for each matrix in `build.sbt`.
 
 ```scala
 val core = (projectMatrix in file("core")).enablePlugins(Snapshot4sPlugin)
+```
+
+Finally, add the integration library for your [test framework](./supported-frameworks.md).
+
+## sbt-crossproject and sbt-typelevel
+
+You can enable the plugin for all cross types, for both JVM and JS.
+
+Add the plugin to `plugins.sbt`.
+
+```scala
+addSbtPlugin("com.siriusxm" % "sbt-snapshot4s" % "@LATEST_STABLE_VERSION@")
+```
+
+Enable the plugin.
+
+```scala
+val core = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Dummy)
+  .in(file("core"))
+  .enablePlugins(Snapshot4sPlugin)
+```
+
+If you use the `Pure` or `Full` cross types, set the `snapshot4sResourceDirectory` to the shared test resource directory.
+
+```scala
+val core = crossProject(JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("core"))
+  .settings(
+    snapshot4sResourceDirectory := CrossType.Pure
+      .sharedResourcesDir(baseDirectory.value, "test")
+      .get / "snapshot",
+  )
+  .enablePlugins(Snapshot4sPlugin)
 ```
 
 Finally, add the integration library for your [test framework](./supported-frameworks.md).

--- a/modules/plugin/src/main/scala/com/siriusxm/snapshot/Snapshot4sPlugin.scala
+++ b/modules/plugin/src/main/scala/com/siriusxm/snapshot/Snapshot4sPlugin.scala
@@ -45,7 +45,7 @@ object generated {
   implicit val snapshotConfig: SnapshotConfig = new SnapshotConfig(
     resourceDirectory = Path("${snapshot4sResourceDirectory.value}"),
     outputDirectory = Path("${snapshot4sDirectory.value}"),
-    sourceDirectory = Path("${(Test / sourceDirectory).value}")
+    sourceDirectory = Path("${sourceBaseDirectory((Test / sourceDirectories).value)}")
   )
 }
  """
@@ -71,10 +71,19 @@ object generated {
       )
       applyInlinePatches(log)(
         snapshot4sDirectory.value / "inline-patch",
-        (Test / sourceDirectory).value
+        sourceBaseDirectory((Test / sourceDirectories).value)
       )
     }
   )
+
+  private def sourceBaseDirectory(sourceDirectories: Seq[File]): File = {
+    def sharedParent(dirA: File, dirB: File): File = {
+      if (dirB.getAbsolutePath().startsWith(dirA.getAbsolutePath())) dirA
+      else if (dirA.getAbsolutePath().startsWith(dirB.getAbsolutePath())) dirB
+      else sharedParent(dirA.getParentFile, dirB)
+    }
+    sourceDirectories.reduce(sharedParent)
+  }
 
   private def applyResourcePatches(log: Logger)(resourcePatchDir: File, resourceDir: File) = {
     val patches = (resourcePatchDir ** (-DirectoryFilter)).get

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/build.sbt
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/build.sbt
@@ -1,27 +1,47 @@
 import snapshot4s.BuildInfo.snapshot4sVersion
 
-// lazy val root = (project in file("."))
-//   .settings(
-//     scalaVersion := "3.3.1",
-//     Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
-//     testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
-//     libraryDependencies += "com.siriusxm" %%% "snapshot4s-weaver" % snapshot4sVersion % Test
-//   )
-//   .enablePlugins(Snapshot4sPlugin, ScalaJSPlugin)
-  
 val Scala3 = "3.3.0"
 ThisBuild / crossScalaVersions := Seq("2.13.11", Scala3)
-ThisBuild / scalaVersion := Scala3 // the default Scala
-ThisBuild / tlBaseVersion := "0.4" // your current series x.y
-
-lazy val root = tlCrossRootProject.aggregate(core)
+ThisBuild / scalaVersion       := Scala3
+ThisBuild / tlBaseVersion      := "0.4"
+lazy val root = tlCrossRootProject.aggregate(core, utils)
 
 lazy val core = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("core"))
   .settings(
-    name := "woozle-core",
-    description := "Core data types and typeclasses",
+    name := "core",
+    snapshot4sResourceDirectory := CrossType.Pure
+      .sharedResourcesDir(baseDirectory.value, "test")
+      .get / "snapshot",
+    testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
+    Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
+    libraryDependencies += "com.siriusxm" %%% "snapshot4s-weaver" % snapshot4sVersion % Test
+  )
+  .enablePlugins(Snapshot4sPlugin)
+
+lazy val utils = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Full)
+  .in(file("utils"))
+  .settings(
+    name := "utils",
+    snapshot4sResourceDirectory := CrossType.Full
+      .sharedResourcesDir(baseDirectory.value, "test")
+      .get / "snapshot",
+    Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
     testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
     libraryDependencies += "com.siriusxm" %%% "snapshot4s-weaver" % snapshot4sVersion % Test
-  ).enablePlugins(Snapshot4sPlugin)
+  )
+  .enablePlugins(Snapshot4sPlugin)
+
+lazy val framework = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Full)
+  .in(file("framework"))
+  .settings(
+    name := "framework",
+    Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
+    testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
+    libraryDependencies += "com.siriusxm" %%% "snapshot4s-weaver" % snapshot4sVersion % Test
+  )
+  .enablePlugins(Snapshot4sPlugin)
+

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/build.sbt
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/build.sbt
@@ -1,0 +1,27 @@
+import snapshot4s.BuildInfo.snapshot4sVersion
+
+// lazy val root = (project in file("."))
+//   .settings(
+//     scalaVersion := "3.3.1",
+//     Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
+//     testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
+//     libraryDependencies += "com.siriusxm" %%% "snapshot4s-weaver" % snapshot4sVersion % Test
+//   )
+//   .enablePlugins(Snapshot4sPlugin, ScalaJSPlugin)
+  
+val Scala3 = "3.3.0"
+ThisBuild / crossScalaVersions := Seq("2.13.11", Scala3)
+ThisBuild / scalaVersion := Scala3 // the default Scala
+ThisBuild / tlBaseVersion := "0.4" // your current series x.y
+
+lazy val root = tlCrossRootProject.aggregate(core)
+
+lazy val core = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("core"))
+  .settings(
+    name := "woozle-core",
+    description := "Core data types and typeclasses",
+    testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
+    libraryDependencies += "com.siriusxm" %%% "snapshot4s-weaver" % snapshot4sVersion % Test
+  ).enablePlugins(Snapshot4sPlugin)

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/core/src/test/resources/snapshot/existing-file
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/core/src/test/resources/snapshot/existing-file
@@ -1,0 +1,1 @@
+old-contents

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/core/src/test/resources/snapshot/nested-directory/nested-file
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/core/src/test/resources/snapshot/nested-directory/nested-file
@@ -1,0 +1,1 @@
+old-contents

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/core/src/test/scala/SimpleTest.scala
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/core/src/test/scala/SimpleTest.scala
@@ -1,0 +1,29 @@
+package simple
+
+import weaver._
+import snapshot4s.weaver.SnapshotExpectations
+import snapshot4s.generated.snapshotConfig
+
+object SimpleTest extends SimpleIOSuite with SnapshotExpectations {
+
+  test("inline") {
+    assertInlineSnapshot(1, 2)
+  }
+
+  test("new inline snapshot") {
+    assertInlineSnapshot(1, ???)
+  }
+
+  test("file that doesn't exist") {
+    assertFileSnapshot("contents", "nonexistent-file")
+  }
+
+  test("existing file") {
+    assertFileSnapshot("contents", "existing-file")
+  }
+
+  test("file in nested directory") {
+    assertFileSnapshot("contents", "nested-directory/nested-file")
+  }
+
+}

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/js/src/test/resources/snapshot/existing-file
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/js/src/test/resources/snapshot/existing-file
@@ -1,0 +1,1 @@
+old-contents

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/js/src/test/resources/snapshot/nested-directory/nested-file
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/js/src/test/resources/snapshot/nested-directory/nested-file
@@ -1,0 +1,1 @@
+old-contents

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/js/src/test/scala/SimpleTest.scala
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/js/src/test/scala/SimpleTest.scala
@@ -1,0 +1,29 @@
+package simple
+
+import weaver._
+import snapshot4s.weaver.SnapshotExpectations
+import snapshot4s.generated.snapshotConfig
+
+object SimpleTest extends SimpleIOSuite with SnapshotExpectations {
+
+  test("inline") {
+    assertInlineSnapshot(1, 2)
+  }
+
+  test("new inline snapshot") {
+    assertInlineSnapshot(1, ???)
+  }
+
+  test("file that doesn't exist") {
+    assertFileSnapshot("contents", "nonexistent-file")
+  }
+
+  test("existing file") {
+    assertFileSnapshot("contents", "existing-file")
+  }
+
+  test("file in nested directory") {
+    assertFileSnapshot("contents", "nested-directory/nested-file")
+  }
+
+}

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/jvm/src/test/resources/snapshot/existing-file
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/jvm/src/test/resources/snapshot/existing-file
@@ -1,0 +1,1 @@
+old-contents

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/jvm/src/test/resources/snapshot/nested-directory/nested-file
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/jvm/src/test/resources/snapshot/nested-directory/nested-file
@@ -1,0 +1,1 @@
+old-contents

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/jvm/src/test/scala/SimpleTest.scala
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/framework/jvm/src/test/scala/SimpleTest.scala
@@ -1,0 +1,29 @@
+package simple
+
+import weaver._
+import snapshot4s.weaver.SnapshotExpectations
+import snapshot4s.generated.snapshotConfig
+
+object SimpleTest extends SimpleIOSuite with SnapshotExpectations {
+
+  test("inline") {
+    assertInlineSnapshot(1, 2)
+  }
+
+  test("new inline snapshot") {
+    assertInlineSnapshot(1, ???)
+  }
+
+  test("file that doesn't exist") {
+    assertFileSnapshot("contents", "nonexistent-file")
+  }
+
+  test("existing file") {
+    assertFileSnapshot("contents", "existing-file")
+  }
+
+  test("file in nested directory") {
+    assertFileSnapshot("contents", "nested-directory/nested-file")
+  }
+
+}

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/project/build.properties
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.3

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/project/build.properties
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.10.1

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/project/plugins.sbt
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/project/plugins.sbt
@@ -1,0 +1,9 @@
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.7.2")
+
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    addSbtPlugin("com.siriusxm" % "sbt-snapshot4s" % x)
+  case _ =>
+    sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/project/plugins.sbt
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.7.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 
 sys.props.get("plugin.version") match {
   case Some(x) =>

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/test
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/test
@@ -1,0 +1,8 @@
+# Generated code should link
+> coreJVM / Test / compile
+# Tests should fail as snapshots are out of date
+-> coreJVM / Test / test
+# Update snapshots
+> snapshot4sPromote
+# Tests should succeed with updated snapshots
+> coreJVM / Test / test

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/test
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/test
@@ -1,8 +1,8 @@
 # Generated code should link
-> coreJVM / Test / compile
+>  Test / compile
 # Tests should fail as snapshots are out of date
--> coreJVM / Test / test
+-> Test / test
 # Update snapshots
 > snapshot4sPromote
 # Tests should succeed with updated snapshots
-> coreJVM / Test / test
+> Test / test

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/utils/shared/src/test/resources/snapshot/existing-file
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/utils/shared/src/test/resources/snapshot/existing-file
@@ -1,0 +1,1 @@
+old-contents

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/utils/shared/src/test/resources/snapshot/nested-directory/nested-file
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/utils/shared/src/test/resources/snapshot/nested-directory/nested-file
@@ -1,0 +1,1 @@
+old-contents

--- a/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/utils/shared/src/test/scala/SimpleTest.scala
+++ b/modules/plugin/src/sbt-test/sbt-snapshot4s/sbt-typelevel/utils/shared/src/test/scala/SimpleTest.scala
@@ -1,0 +1,29 @@
+package simple
+
+import weaver._
+import snapshot4s.weaver.SnapshotExpectations
+import snapshot4s.generated.snapshotConfig
+
+object SimpleTest extends SimpleIOSuite with SnapshotExpectations {
+
+  test("inline") {
+    assertInlineSnapshot(1, 2)
+  }
+
+  test("new inline snapshot") {
+    assertInlineSnapshot(1, ???)
+  }
+
+  test("file that doesn't exist") {
+    assertFileSnapshot("contents", "nonexistent-file")
+  }
+
+  test("existing file") {
+    assertFileSnapshot("contents", "existing-file")
+  }
+
+  test("file in nested directory") {
+    assertFileSnapshot("contents", "nested-directory/nested-file")
+  }
+
+}


### PR DESCRIPTION
This PR resolves #28  by:
 - Using a shared source directory as a snapshot path prefix.
 - Recommending users to configure their `snapshot4sResourceDirectory` explicitly for `Pure` and `Full` cross types.

