### PR TITLE
Increase the height of pprint output

### DIFF
--- a/modules/core/src/main/scala-2/com/siriusxm/snapshot4s/ReprForAdt.scala
+++ b/modules/core/src/main/scala-2/com/siriusxm/snapshot4s/ReprForAdt.scala
@@ -22,7 +22,8 @@ trait ReprForAdt {
 
   // Mirror is only used to guarantee we are working with sum/product
   // in such case it's safe to rely on pprint instead of having a separate Repr implementation
-  implicit def productRepr[A <: Product]: Repr[A] = v =>  pprint.apply(v, width = 200, height = 99999999).plainText
+  implicit def productRepr[A <: Product]: Repr[A] = v =>
+    pprint.apply(v, width = 200, height = 99999999).plainText
   implicit def sumRepr[A]: Repr[A] = macro ReprForSum.impl[A]
 
 }

--- a/modules/core/src/main/scala-2/com/siriusxm/snapshot4s/ReprForAdt.scala
+++ b/modules/core/src/main/scala-2/com/siriusxm/snapshot4s/ReprForAdt.scala
@@ -23,6 +23,7 @@ trait ReprForAdt {
   // Mirror is only used to guarantee we are working with sum/product
   // in such case it's safe to rely on pprint instead of having a separate Repr implementation
   implicit def productRepr[A <: Product]: Repr[A] = v =>
+    // width and height are overridden to handle very large snapshots
     pprint.apply(v, width = 200, height = 99999999).plainText
   implicit def sumRepr[A]: Repr[A] = macro ReprForSum.impl[A]
 

--- a/modules/core/src/main/scala-2/com/siriusxm/snapshot4s/ReprForAdt.scala
+++ b/modules/core/src/main/scala-2/com/siriusxm/snapshot4s/ReprForAdt.scala
@@ -22,7 +22,7 @@ trait ReprForAdt {
 
   // Mirror is only used to guarantee we are working with sum/product
   // in such case it's safe to rely on pprint instead of having a separate Repr implementation
-  implicit def productRepr[A <: Product]: Repr[A] = pprint.apply(_).plainText
+  implicit def productRepr[A <: Product]: Repr[A] = v =>  pprint.apply(v, width = 200, height = 99999999).plainText
   implicit def sumRepr[A]: Repr[A] = macro ReprForSum.impl[A]
 
 }

--- a/modules/core/src/main/scala/com/siriusxm/snapshot4s/Repr.scala
+++ b/modules/core/src/main/scala/com/siriusxm/snapshot4s/Repr.scala
@@ -60,6 +60,6 @@ object Repr extends ReprForAdt {
   ): Repr[Either[L, R]] = fromPprint
 
   // Creates Repr instance based on pprint
-  def fromPprint[A]: Repr[A] = (a: A) => pprint.apply(a).plainText
+  def fromPprint[A]: Repr[A] = (a: A) => pprint.apply(a, width = 200, height = 99999999).plainText
 
 }

--- a/modules/core/src/main/scala/com/siriusxm/snapshot4s/Repr.scala
+++ b/modules/core/src/main/scala/com/siriusxm/snapshot4s/Repr.scala
@@ -60,6 +60,8 @@ object Repr extends ReprForAdt {
   ): Repr[Either[L, R]] = fromPprint
 
   // Creates Repr instance based on pprint
-  def fromPprint[A]: Repr[A] = (a: A) => pprint.apply(a, width = 200, height = 99999999).plainText
+  def fromPprint[A]: Repr[A] = (a: A) =>
+    // width and height are overridden to handle very large snapshots
+    pprint.apply(a, width = 200, height = 99999999).plainText
 
 }


### PR DESCRIPTION
This PR fixes an issue with very large snapshots by increasing the height limit of pprint output