### PR TITLE
Use Repr when printing failure diff.

### DIFF
--- a/modules/munit/src/main/scala/com/siriusxm/snapshot4s/munit/MunitResultLike.scala
+++ b/modules/munit/src/main/scala/com/siriusxm/snapshot4s/munit/MunitResultLike.scala
@@ -23,18 +23,19 @@ import snapshot4s.*
 
 private object MunitResultLike {
 
-  def resultLike[A](loc: Location, diffOptions: DiffOptions): ResultLike[A, Unit] =
+  def resultLike[A](loc: Location, diffOptions: DiffOptions, repr: Repr[A]): ResultLike[A, Unit] =
     new ResultLike[A, Unit] {
 
       def apply(result: () => Result[A]): Unit = {
-        resultToAssertion(result(), loc, diffOptions)
+        resultToAssertion(result(), loc, diffOptions, repr)
       }
     }
 
   private def resultToAssertion[A](
       result: Result[A],
       loc: Location,
-      diffOptions: DiffOptions
+      diffOptions: DiffOptions,
+      repr: Repr[A]
   ): Unit = {
     result match {
       case _: Result.Success[?]     => ()
@@ -42,7 +43,10 @@ private object MunitResultLike {
         throw Assertions.fail(ErrorMessages.nonExistent)(loc, diffOptions)
       case Result.Failure(found, snapshot) =>
         throw Assertions
-          .fail(diffReport(found.toString, snapshot.toString, diffOptions))(loc, diffOptions)
+          .fail(diffReport(repr.toSourceString(found), repr.toSourceString(snapshot), diffOptions))(
+            loc,
+            diffOptions
+          )
     }
   }
 

--- a/modules/munit/src/main/scala/com/siriusxm/snapshot4s/munit/SnapshotAssertions.scala
+++ b/modules/munit/src/main/scala/com/siriusxm/snapshot4s/munit/SnapshotAssertions.scala
@@ -19,7 +19,7 @@ package snapshot4s.munit
 import _root_.munit.Location
 import _root_.munit.diff.DiffOptions
 
-import snapshot4s.{ResultLike, SnapshotAssertions as CoreSnapshotAssertions, SnapshotEq}
+import snapshot4s.{Repr, ResultLike, SnapshotAssertions as CoreSnapshotAssertions, SnapshotEq}
 
 trait SnapshotAssertions extends CoreSnapshotAssertions[Unit] {
 
@@ -27,9 +27,10 @@ trait SnapshotAssertions extends CoreSnapshotAssertions[Unit] {
 
   implicit def munitResultLike[A](implicit
       loc: Location,
-      diffOptions: DiffOptions
+      diffOptions: DiffOptions,
+      repr: Repr[A]
   ): ResultLike[A, Unit] =
-    MunitResultLike.resultLike[A](loc, diffOptions)
+    MunitResultLike.resultLike[A](loc, diffOptions, repr)
 }
 
 object SnapshotAssertions extends SnapshotAssertions

--- a/modules/scalatest/src/main/scala/com/siriusxm/snapshot4s/scalatest/ScalaTestResultLike.scala
+++ b/modules/scalatest/src/main/scala/com/siriusxm/snapshot4s/scalatest/ScalaTestResultLike.scala
@@ -27,18 +27,23 @@ import snapshot4s.*
 
 private object ScalaTestResultLike {
 
-  def resultLike[A](pos: Position, prettifier: Prettifier): ResultLike[A, Assertion] =
+  def resultLike[A](
+      pos: Position,
+      prettifier: Prettifier,
+      repr: Repr[A]
+  ): ResultLike[A, Assertion] =
     new ResultLike[A, Assertion] {
 
       def apply(result: () => Result[A]): Assertion = {
-        resultToAssertion(result(), pos, prettifier)
+        resultToAssertion(result(), pos, prettifier, repr)
       }
     }
 
   private def resultToAssertion[A](
       result: Result[A],
       pos: Position,
-      prettifier: Prettifier
+      prettifier: Prettifier,
+      repr: Repr[A]
   ): Assertion = {
     result match {
       case _: Result.Success[?]     => Succeeded
@@ -51,7 +56,7 @@ private object ScalaTestResultLike {
           analysis = IndexedSeq.empty[String]
         )
       case Result.Failure(found, snapshot) =>
-        val diff = prettifier(found, snapshot)
+        val diff = prettifier(repr.toSourceString(found), repr.toSourceString(snapshot))
         throw new TestFailedException(
           _ => Some(s"${ErrorMessages.failure} Expected: ${diff.right}, but got ${diff.left}"),
           cause = None,

--- a/modules/scalatest/src/main/scala/com/siriusxm/snapshot4s/scalatest/SnapshotAssertions.scala
+++ b/modules/scalatest/src/main/scala/com/siriusxm/snapshot4s/scalatest/SnapshotAssertions.scala
@@ -20,7 +20,7 @@ import org.scalactic.Prettifier
 import org.scalactic.source.Position
 import org.scalatest.Assertion
 
-import snapshot4s.{ResultLike, SnapshotAssertions as CoreSnapshotAssertions, SnapshotEq}
+import snapshot4s.{Repr, ResultLike, SnapshotAssertions as CoreSnapshotAssertions, SnapshotEq}
 
 trait SnapshotAssertions extends CoreSnapshotAssertions[Assertion] {
 
@@ -28,9 +28,10 @@ trait SnapshotAssertions extends CoreSnapshotAssertions[Assertion] {
 
   implicit def scalatestResultLike[A](implicit
       pos: Position,
-      prettifier: Prettifier
+      prettifier: Prettifier,
+      repr: Repr[A]
   ): ResultLike[A, Assertion] =
-    ScalaTestResultLike.resultLike[A](pos, prettifier)
+    ScalaTestResultLike.resultLike[A](pos, prettifier, repr)
 }
 
 object SnapshotAssertions extends SnapshotAssertions

--- a/modules/weaver/src/main/scala/com/siriusxm/snapshot4s/weaver/SnapshotExpectations.scala
+++ b/modules/weaver/src/main/scala/com/siriusxm/snapshot4s/weaver/SnapshotExpectations.scala
@@ -34,8 +34,11 @@ private[weaver] trait SnapshotEqInstances extends LowPrioritySnapshotEq {
 
 trait SnapshotExpectations extends SnapshotAssertions[IO[Expectations]] with SnapshotEqInstances {
 
-  implicit def weaverResultLike[A](implicit loc: SourceLocation): ResultLike[A, IO[Expectations]] =
-    WeaverResultLike.resultLike[A](loc)
+  implicit def weaverResultLike[A](implicit
+      loc: SourceLocation,
+      reprA: Repr[A]
+  ): ResultLike[A, IO[Expectations]] =
+    WeaverResultLike.resultLike[A](loc, reprA)
 }
 
 object SnapshotExpectations extends SnapshotExpectations

--- a/modules/weaver/src/main/scala/com/siriusxm/snapshot4s/weaver/WeaverResultLike.scala
+++ b/modules/weaver/src/main/scala/com/siriusxm/snapshot4s/weaver/WeaverResultLike.scala
@@ -20,20 +20,21 @@ import _root_.weaver.{ExpectationFailed, Expectations, SourceLocation}
 import cats.data.{NonEmptyList, Validated}
 import cats.effect.IO
 
-import snapshot4s.{ErrorMessages, Result, ResultLike}
+import snapshot4s.{ErrorMessages, Repr, Result, ResultLike}
 
 object WeaverResultLike {
 
-  def resultLike[A](loc: SourceLocation): ResultLike[A, IO[Expectations]] =
+  def resultLike[A](loc: SourceLocation, repr: Repr[A]): ResultLike[A, IO[Expectations]] =
     new ResultLike[A, IO[Expectations]] {
       type Assertion = IO[Expectations]
       def apply(result: () => Result[A]): Assertion =
-        IO(result()).map(resultToExpectations(_, loc))
+        IO(result()).map(resultToExpectations(_, loc, repr))
     }
 
   def resultToExpectations[A](
       result: Result[A],
-      loc: SourceLocation
+      loc: SourceLocation,
+      repr: Repr[A]
   ): Expectations = {
     result match {
       case _: Result.Success[?]     => Expectations.Helpers.success
@@ -46,7 +47,10 @@ object WeaverResultLike {
       case Result.Failure(found, snapshot) =>
         Expectations(
           Validated.invalidNel[ExpectationFailed, Unit](
-            new ExpectationFailed(Diff(found.toString, snapshot.toString), NonEmptyList.of(loc))
+            new ExpectationFailed(
+              Diff(repr.toSourceString(found), repr.toSourceString(snapshot)),
+              NonEmptyList.of(loc)
+            )
           )
         )
     }


### PR DESCRIPTION
The following test is expected to fail, however it's error message could be improved:

```scala
  test("nel repr") {
    import cats.data.NonEmptyList

    implicit val nelRepr: Repr[NonEmptyList[Int]] = new Repr[NonEmptyList[Int]] {
      def toSourceString(nel: NonEmptyList[Int]): String =
        s"""NonEmptyList.of(${nel.toList.mkString(",")})"""
    }

    val input = NonEmptyList.of(1, 2, 3)
    assertInlineSnapshot(input, NonEmptyList.of(3, 4, 5))
  }
```

It fails with:

<img width="372" height="119" alt="image" src="https://github.com/user-attachments/assets/538ee6fb-0851-4454-a776-722d879a172c" />

It would be great if we could use the source representation in the diff, and instead display `NonEmptyList.of(1, 2, 3)`.

This is a little tricky to test, as the weaver `ExpectationFailed` message is private.
