### PR TITLE
Fix `Repr` instance for type lambdas in Scala 2

### DIFF
--- a/modules/core/src/main/scala-2/com/siriusxm/snapshot4s/ReprForAdt.scala
+++ b/modules/core/src/main/scala-2/com/siriusxm/snapshot4s/ReprForAdt.scala
@@ -146,7 +146,15 @@ https://siriusxm.github.io/snapshot4s/inline-snapshots/#supported-data-types"""
   private def deriveSumRepr[A: c.WeakTypeTag](c: blackbox.Context): c.Expr[Repr[A]] = {
     import c.universe._
 
-    val tpe         = weakTypeOf[A]
+    // Remove any type aliases.
+    // For example in:
+    // {
+    //   type MyType[X] = Either[X, Int]
+    //   val repr = Repr.derived[MyType[Boolean]]
+    // }
+    // The `typeOrAlias` is `MyType[Boolean]`, but the `tpe` is `Either[A, B]`
+    val typeOrAlias = weakTypeOf[A]
+    val tpe         = typeOrAlias.baseType(typeOrAlias.typeSymbol.asType)
     val classSymbol = tpe.typeSymbol.asClass
 
     if (!classSymbol.isSealed) {

--- a/modules/core/src/test/scala/com/siriusxm/snapshot4s/ReprTestCases.scala
+++ b/modules/core/src/test/scala/com/siriusxm/snapshot4s/ReprTestCases.scala
@@ -210,4 +210,11 @@ trait ReprTestCases { self: FunSuite =>
     val input = (42, "hello", true)
     expect.same("""(42, "hello", true)""", repr.toSourceString(input))
   }
+
+  test("obtain Repr instance for type lambdas") {
+    type MyType[A] = Either[Int, A]
+    val repr                       = Repr.derived[MyType[String]]
+    val input: Either[Int, String] = Left(42)
+    expect.same("Left(value = 42)", repr.toSourceString(input))
+  }
 }


### PR DESCRIPTION
The `Repr` derivation currently fails for curried type aliases.

Without the fix, the added test fails with:

```
[error] snapshot4s/modules/core/src/test/scala-2/com/siriusxm/snapshot4s/ReprSpec.scala:80:29: pattern type is incompatible with expected type;
[error]  found   : scala.util.Left
[error]  required: scala.util.Either[Int,String]
[error]     val repr  = Repr.derived[MyType[String]]
[error]                             ^
[error] one error found
```
