### PR TITLE
Add instructions for regenerating snapshots on datatype changes.

### DIFF
--- a/docs/markdown/inline-snapshots.md
+++ b/docs/markdown/inline-snapshots.md
@@ -86,7 +86,7 @@ assertInlineSnapshot(found = Person("Alice"), Person("Alice"))
 assertInlineSnapshot(found = Nil, List(Person("Alice"), Person("Bob")))
 ```
 
-## Unsupported data types
+### Unsupported data types
 
 It should not be used on variables.
 
@@ -102,3 +102,28 @@ It fails to compile for values that can't be represented as source code.
 assertInlineSnapshot(found = new Object(), new Object())
 ```
 
+## Updating snapshots
+
+You can update snapshot values using `sbt test` and `sbt snapshot4sPromote`.
+
+If your datatype changes in structure, you can use [scalafix](https://scalacenter.github.io/scalafix/) to reset your snapshots.
+
+For example, suppose you wish to add a `version` field to `Config`:
+
+```diff
+ case class Config(
+   environment: String, 
+   region: String, 
++  version: String
+ )
+```
+
+If you make the change as-is, your tests will fail to compile and you will not be able to update them with `snapshot4sPromote`.
+
+You can update your snapshots efficiently using the following steps:
+ - *Before* making the code change, replace all snapshot values with `???`. You can use the `ResetSnapshots` scalafix rule.
+    ```
+    sbt scalafixAll --rules=github:siriusxm/snapshot4s/ResetSnapshots
+    ```
+ - Make your code change.
+ - Your snapshot tests will compile. Regenerate snapshots with `sbt test` and `sbt snapshot4sPromote`.

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,0 +1,42 @@
+lazy val V = _root_.scalafix.sbt.BuildInfo
+inThisBuild(
+  List(
+    organization := "com.siriusxm",
+    homepage := Some(url("https://github.com/siriusxm/snapshot4s")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    scalaVersion := V.scala213,
+    semanticdbEnabled := true,
+    semanticdbIncludeInJar := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
+    scalacOptions ++= List("-Yrangepos")
+  )
+)
+
+(publish / skip) := true
+
+lazy val rules = project.settings(
+  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
+)
+
+lazy val input = project.settings(
+  (publish / skip) := true,
+
+)
+
+lazy val output = project.settings(
+  (publish / skip) := true
+)
+
+lazy val tests = project
+  .settings(
+    (publish / skip) := true,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
+    scalafixTestkitOutputSourceDirectories :=
+      (output / Compile / unmanagedSourceDirectories).value,
+    scalafixTestkitInputSourceDirectories :=
+      (input / Compile / unmanagedSourceDirectories).value,
+    scalafixTestkitInputClasspath :=
+      (input / Compile / fullClasspath).value
+  )
+  .dependsOn(rules)
+  .enablePlugins(ScalafixTestkitPlugin)

--- a/scalafix/input/src/main/scala/test/SimpleTest.scala
+++ b/scalafix/input/src/main/scala/test/SimpleTest.scala
@@ -1,0 +1,17 @@
+/*
+rule = ResetSnapshots
+ */
+package simple
+
+trait TestStub {
+  def assertInlineSnapshot[A](actual: A, expected: A): Unit = ()
+
+  def test(name: String)(f: Unit): Unit = ()
+}
+
+object SimpleTest extends TestStub {
+
+  test("simple") {
+    assertInlineSnapshot(1, 2)
+  }
+}

--- a/scalafix/output/src/main/scala/test/SimpleTest.scala
+++ b/scalafix/output/src/main/scala/test/SimpleTest.scala
@@ -1,0 +1,14 @@
+package simple
+
+trait TestStub {
+  def assertInlineSnapshot[A](actual: A, expected: A): Unit = ()
+
+  def test(name: String)(f: Unit): Unit = ()
+}
+
+object SimpleTest extends TestStub {
+
+  test("simple") {
+    assertInlineSnapshot(1, ???)
+  }
+}

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.3

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("releases")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.6")

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+ResetSnapshots

--- a/scalafix/rules/src/main/scala/fix/ResetSnapshots.scala
+++ b/scalafix/rules/src/main/scala/fix/ResetSnapshots.scala
@@ -1,0 +1,11 @@
+import scalafix.v1._
+import scala.meta._
+
+class ResetSnapshots extends SyntacticRule("ResetSnapshots") {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
+    doc.tree.collect {
+      case tree @ q"assertInlineSnapshot($found, $expected)" =>
+        Patch.replaceTree(tree, s"assertInlineSnapshot($found, ???)")
+    }.asPatch
+  }
+}

--- a/scalafix/tests/src/test/scala/fix/RuleSuite.scala
+++ b/scalafix/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,0 +1,8 @@
+package fix
+
+import scalafix.testkit._
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+class RuleSuite extends AbstractSemanticRuleSuite with AnyFunSuiteLike {
+  runAllTests()
+}

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -109,7 +109,7 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} SiriusXM.`,
     },
     prism: {
-      additionalLanguages: ['java', 'scala'],
+      additionalLanguages: ['java', 'scala', 'diff'],
       theme: prismThemes.github,
       darkTheme: prismThemes.oneDark,
     },


### PR DESCRIPTION
Adds a scalafix rule to reset snapshots.

This can be tested with:

```
sbt scalafix --rules=github:zainab-ali/snapshot4s/RegenerateSnapshots?sha=reset-snapshots-rule
```

<img width="802" height="525" alt="image" src="https://github.com/user-attachments/assets/468e95ee-8532-463b-9f44-faa29d5e104c" />

Note that the `scalafix` module hasn't been added to the CI build matrix as it's independent of the main codebase. We'll need to run it manually when making updates.